### PR TITLE
Fix cmake flag typo.

### DIFF
--- a/.popper.yml
+++ b/.popper.yml
@@ -22,7 +22,7 @@ steps:
   uses: docker://uccross/skyhookdm-builder:nautilus
   runs: [bash]
   env:
-    CMAKE_FLAGS: "-DBOOST_J=4 -DDCMAKE_BUILD_TYPE=Release"
+    CMAKE_FLAGS: "-DBOOST_J=4 -DCMAKE_BUILD_TYPE=Release"
     BUILD_THREADS: "4"
   args: [scripts/build.sh]
 


### PR DESCRIPTION
Fixes small typo (cmake flag) in popper.yml

Previously was getting cmake warning:
```
-- Disabling Kafka endpoint support
-- exclude following files under src: *.js;*.css;civetweb;erasure-code/jerasure/jerasure;erasure-code/jerasure/gf-complete;rocksdb;googletest;spdk;xxHash;isa-l;lua;zstd;crypto/isa-l/isa-l_crypto;blkin;rapidjson;dmclock;seastar;c-ares
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    DCMAKE_BUILD_TYPE


-- Build files have been written to: /workspace/ceph/build
Scanning dependencies of target Boost
Creating directories for 'Boost'
Performing download step (download, verify and extract) for 'Boost'
-- Downloading...
```
now fixed:
```
-- Disabling Kafka endpoint support
-- exclude following files under src: *.js;*.css;civetweb;erasure-code/jerasure/jerasure;erasure-code/jerasure/gf-complete;rocksdb;googletest;spdk;xxHash;isa-l;lua;zstd;crypto/isa-l/isa-l_crypto;blkin;rapidjson;dmclock;seastar;c-ares
-- Configuring done
-- Generating done
-- Build files have been written to: /workspace/ceph/build
Scanning dependencies of target Boost
Creating directories for 'Boost'
Performing download step (download, verify and extract) for 'Boost'
-- Downloading...
```