### PR TITLE
copy run-query binary inside the image

### DIFF
--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -9,5 +9,6 @@ RUN yum update -y && \
       parquet-devel && \
     yum clean all
 
+COPY ceph/build/bin/run-query /usr/bin/
 COPY ceph/build/bin/ceph_test_skyhook_query /usr/bin/
 COPY ceph/build/lib/libcls_tabular.so* /usr/lib64/rados-classes/


### PR DESCRIPTION
We need the `run-query` binary in the image to be able to run the test queries. Please tell me if you would like me to add the other binaries like `cls_tabular` and `sky_tabular_flatflex_writer` in a similar way. TravisCI logs [here](https://travis-ci.org/github/JayjeetAtGithub/skyhookdm-ceph-cls/builds/700798310).